### PR TITLE
Add exception handling when Discord is not running

### DIFF
--- a/hooks.py
+++ b/hooks.py
@@ -14,7 +14,7 @@ def view_hook(main):
             title = main.db.field_for('title', book_ids[0], default_value='Unknown')
             author = main.db.field_for('authors', book_ids[0], default_value='Unknown Author')[0]
 
-            if main.RPC is not None:
+            if main.RPC.enabled():
                 main.RPC.update(Action.VIEW, details='Reading: ' + title, state='By: ' + author)
 
     main.gui.iactions['View']._view_calibre_books = _view_calibre_books
@@ -31,7 +31,7 @@ def edit_hook(main):
         title = main.db.field_for('title', book_id, default_value='Unknown')
         author = main.db.field_for('authors', book_id, default_value='Unknown Author')[0]
 
-        if main.RPC is not None:
+        if main.RPC.enabled():
             main.RPC.update(Action.EDIT, details='Editing: ' + title, state='By: ' + author)
 
     main.gui.iactions['Tweak ePub'].do_tweak = do_tweak

--- a/pypresence/baseclient.py
+++ b/pypresence/baseclient.py
@@ -91,8 +91,9 @@ class BaseClient:
             payload = payload.data
         payload = json.dumps(payload)
 
-        assert self.sock_writer is not None, "You must connect your client before sending events!"
-
+        if self.sock_writer is None:
+            raise DiscordNotFound
+        
         self.sock_writer.write(
             struct.pack(
                 '<II',

--- a/pypresence/exceptions.py
+++ b/pypresence/exceptions.py
@@ -7,7 +7,7 @@ class PyPresenceException(Exception):
 
 class DiscordNotFound(PyPresenceException):
     def __init__(self):
-        super().__init__('Could not find Discord installed and running on this machine.')
+        super().__init__('Could not find Discord installed and running on this machine. Please run Discord and then start Calibre RPC.')
 
 
 class InvalidPipe(PyPresenceException):

--- a/rpc.py
+++ b/rpc.py
@@ -1,5 +1,4 @@
 import time
-
 from enum import Enum
 from calibre_plugins.calibre_rpc.pypresence.presence import Presence
 
@@ -12,30 +11,28 @@ class Action(Enum):
 
 class RPC:
     def __init__(self):
-        self.Presence = None
+        self.connected = False
 
     def start(self):
-        if self.Presence is None:
-            client_id = '1163996659886346270'
-            self.Presence = Presence(client_id, pipe=0)
-
+        client_id = '1163996659886346270'
+        self.Presence = Presence(client_id, pipe=0)
         self.Presence.connect()
+        self.connected = True
+            
 
     def update(self, action, details=None, state=None):
-        if not self.enabled():
-            return
-
         # TODO: use a switch on the action for different images
-
         self.Presence.update(details=details, state=state, large_image="calibre", large_text="Calibre",
-                             start=time.time(),
-                             buttons=[{"label": "Download Calibre", "url": "https://calibre-ebook.com/"}])
+                            start=time.time(),
+                            buttons=[{"label": "Download Calibre", "url": "https://calibre-ebook.com/"}])
 
-    def enabled(self):
-        return self.Presence is not None
 
     def shutdown(self):
-        if self.enabled():
+        if self.connected:
             self.Presence.clear()
             self.Presence.close()
-            self.Presence = None
+            self.connected = False
+
+
+    def is_connected(self):
+        return self.connected


### PR DESCRIPTION
## Changes
- Prompt an error message if Discord is not running when Calibre RPC tries to connect
- Edit DiscordNotFound exception message
- Raise DiscordNotFound when socket writer is None